### PR TITLE
Handle concurrency for booking a ticket

### DIFF
--- a/src/main/java/com/debasish/bookmyshow/repository/ShowSeatRepository.java
+++ b/src/main/java/com/debasish/bookmyshow/repository/ShowSeatRepository.java
@@ -1,11 +1,19 @@
 package com.debasish.bookmyshow.repository;
 
 import com.debasish.bookmyshow.model.ShowSeat;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface ShowSeatRepository extends JpaRepository<ShowSeat, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+        //putting pessimistic lock on the below query
+    List<ShowSeat> findByIdIn(List<Long> showSeatIds); // select * from showSeat where id in (...);
 
     ShowSeat save(ShowSeat seat); // insert new record and update an existing record
 }

--- a/src/main/java/com/debasish/bookmyshow/service/TicketService.java
+++ b/src/main/java/com/debasish/bookmyshow/service/TicketService.java
@@ -1,6 +1,8 @@
 package com.debasish.bookmyshow.service;
 
 import com.debasish.bookmyshow.exception.ShowSeatNotAvailableException;
+import com.debasish.bookmyshow.model.ShowSeat;
+import com.debasish.bookmyshow.model.ShowSeatStatus;
 import com.debasish.bookmyshow.model.Ticket;
 import com.debasish.bookmyshow.repository.ShowRepository;
 import com.debasish.bookmyshow.repository.ShowSeatRepository;
@@ -26,22 +28,38 @@ public class TicketService {
         this.showRepository = showRepository;
     }
 
-
     @Transactional(isolation = Isolation.SERIALIZABLE) //sets the Transaction isolation level as SERIALIZABLE
     public Ticket bookTicket(Long showId, List<Long> showSeatIds, Long userId) throws ShowSeatNotAvailableException {
         //Fetch all the given showSeats from the table
+        List<ShowSeat> showSeats = showSeatRepository.findByIdIn(showSeatIds);
 
         //Check if all of them are available
+        for (ShowSeat showSeat : showSeats) {
+            if (!showSeat.getSeatStatus().equals(ShowSeatStatus.AVAILABLE)) {
+                throw new ShowSeatNotAvailableException("Show seat is not available");
+            }
+        }
 
         //If all are available then make them locked
+        for (ShowSeat showSeat : showSeats) {
+            showSeat.setSeatStatus(ShowSeatStatus.LOCKED);
+            showSeatRepository.save(showSeat);
+        }
 
         //wait for payment confirmation
         //assuming payment is done
         //create and return the ticket object
-
+        Ticket ticket = new Ticket();
+        ticket.setShowSeats(showSeats);
+        ticket.setShow(showRepository.findById(showId).get());
         //set other details for ticket
+        ticket = ticketRepository.save(ticket);
 
         //mark them booked after ticket is done
-        return null;
+        for (ShowSeat showSeat : showSeats) {
+            showSeat.setSeatStatus(ShowSeatStatus.BOOKED);
+            showSeatRepository.save(showSeat);
+        }
+        return ticket;
     }
 }


### PR DESCRIPTION
Set the transaction level as Serializable while booking a ticket and apply a pessimistic write lock while fetching the show seats.

`@Transactional(isolation = Isolation.SERIALIZABLE)` and `@Lock(LockModeType.PESSIMISTIC_WRITE)` : This solves the concurrency issues but will impact the speed as parallel operations can't go through.